### PR TITLE
Function to insert hash symbol

### DIFF
--- a/helpers.el
+++ b/helpers.el
@@ -17,6 +17,15 @@
 
 
 ;;
+;; Insert Hash
+;;
+
+(defun insert-hash()
+  "Inserts a hash into the buffer"
+  (interactive)
+  (insert "#"))
+
+;;
 ;; Duplicate Line
 ;;
 

--- a/keybindings.el
+++ b/keybindings.el
@@ -103,6 +103,9 @@
 (define-key global-map (kbd "C-c r") 'org-remember)
 (define-key global-map (kbd "C-M-r") 'org-remember)
 
+;; Allow hash to be entered
+(global-set-key (kbd "M-3") 'insert-hash)
+
 ;; ElScreen related shortcuts
 (when (require 'elscreen nil 'noerror)
 


### PR DESCRIPTION
With a UK keyboard layout you are unable to insert # symbols, this adds a custom mapping to enable you to do so.
