### PR TITLE
Add less-css-mode package

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -46,6 +46,7 @@
     haml-mode
     highlight-indentation
     inf-ruby
+    less-css-mode
     magit
     magithub
     markdown-mode


### PR DESCRIPTION
Emacs mode for LESS CSS (lesscss.org), with support for flymake and compile-on-save
